### PR TITLE
config: Optimize dex2oat for cortex-a76 on cortex-a510

### DIFF
--- a/config/BoardConfigLineage.mk
+++ b/config/BoardConfigLineage.mk
@@ -5,3 +5,9 @@ include hardware/qcom-caf/common/BoardConfigQcom.mk
 endif
 
 include vendor/lineage/config/BoardConfigSoong.mk
+
+# Dex2oat
+ifeq ($(TARGET_CPU_VARIANT),cortex-a510)
+    DEX2OAT_TARGET_CPU_VARIANT := cortex-a76
+    DEX2OAT_TARGET_CPU_VARIANT_RUNTIME := cortex-a76
+endif


### PR DESCRIPTION
A510 is not supported in mainline ART. Kryo785 is supported, but does not enable DotProd. Currently, A76 is the target that enables all the features we want.

dex2oatd E 12-27 23:35:27 3642344 3642344 dex2oat.cc:222] Unexpected CPU variant for Arm64: cortex-a510.
dex2oatd E 12-27 23:35:27 3642344 3642344 dex2oat.cc:222] Known variants that need a fix for a53 erratum 835769: default, generic, cortex-a53, cortex-a53.a57, cortex-a53.a72, cortex-a57, cortex-a72, cortex-a73.
dex2oatd E 12-27 23:35:27 3642344 3642344 dex2oat.cc:222] Known variants that do not need a fix for a53 erratum 835769: cortex-a35, cortex-a55, cortex-a75, cortex-a76, exynos-m1, exynos-m2, exynos-m3, kryo, kryo300, kryo385, kryo785

Change-Id: I496143af83179896136b78802a3f7d7bd99ad3b4